### PR TITLE
Added documentation and various enhancements

### DIFF
--- a/Messenger-Server/Client.cs
+++ b/Messenger-Server/Client.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Messenger_Server
@@ -21,6 +18,10 @@ namespace Messenger_Server
             this.writer = new StreamWriter(client.GetStream());
         }
 
+        /// <summary>
+        /// Continuously try to read data from the stream. Any incoming message is
+        /// handed to a seperate Task, which is responsible for handling the message.
+        /// </summary>
         public void ReadData()
         {
             while (true)
@@ -42,6 +43,10 @@ namespace Messenger_Server
             }
         }
 
+        /// <summary>
+        /// Send a message to this client.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
         public void SendData(Message message)
         {
             writer.WriteLine(Message.SerializeMessage(message));

--- a/Messenger-Server/CommunicationHandler.cs
+++ b/Messenger-Server/CommunicationHandler.cs
@@ -1,42 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
-
-namespace Messenger_Server
+﻿namespace Messenger_Server
 {
     public class CommunicationHandler
     {
-        private static JsonMessage Parse(String jsonString)
-        {
-            JsonSerializerOptions deserializerOptions = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            };
-            return JsonSerializer.Deserialize<JsonMessage>(jsonString, deserializerOptions);
-        }
-
         /// <summary>
         /// This method is called by the ReadData method in Client.
         /// It handles all incoming messages from clients.
         /// </summary>
-        /// <param name="client"></param>
-        /// <param name="jsonString"></param>
+        /// <param name="message">The incoming message.</param>
         public static void HandleMessage(Message message)
         {
-
             if (message.MessageType.Equals("chatMessage"))
             {
+                // Relay the chatMessage to all other clients in the group.
                 Server.Instance.GetGroup(message.GroupID).SendMessageToClients(message);
             }
             else if (message.MessageType.Equals("registerGroup"))
             {
-                int groupId = Server.Instance.CreateGroup(message.PayloadData);
+                // Create a new group, add the sender as initial group member
+                // and return the ID of the new group.
+                Group newGroup = Server.Instance.CreateGroup(message.PayloadData);
+                newGroup.AddClient(message.Sender);
                 Message m = new Message()
                 {
-                    GroupID = groupId,
+                    GroupID = newGroup.GroupID,
                     MessageType = "registerGroupResponse"
                 };
                 message.Sender.SendData(m);

--- a/Messenger-Server/Group.cs
+++ b/Messenger-Server/Group.cs
@@ -1,50 +1,81 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Messenger_Server
 {
     public class Group
     {
-        private List<Client> clients;
-        private Object clientsLock = new Object();
-        public String Name { get; set; }
+        /// <summary>
+        /// List with all clients currently registered in the group.
+        /// </summary>
+        private readonly List<Client> clients;
+
+        /// <summary>
+        /// Lock for reading from and writing to the clients list.
+        /// </summary>
+        private readonly ReaderWriterLockSlim clientsLock = new ReaderWriterLockSlim();
+
+        /// <summary>
+        /// The name of the group.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The ID of the group.
+        /// </summary>
         public int GroupID { get; set; }
 
-        public Group(String name, int id)
+        public Group(string name, int id)
         {
             this.Name = name;
             this.GroupID = id;
+            this.clients = new List<Client>();
         }
 
+        /// <summary>
+        /// Add a new client to the group. This method is thread-safe.
+        /// </summary>
+        /// <param name="client">The client to add.</param>
         public void AddClient(Client client)
         {
-            lock (clientsLock)
-            {
-                this.clients.Add(client);
-            }
+            clientsLock.EnterWriteLock();
+            this.clients.Add(client);
+            clientsLock.ExitWriteLock();
         }
 
+        /// <summary>
+        /// Remove a client from the group. This method is thread-safe.
+        /// </summary>
+        /// <param name="client">The client to remove.</param>
         public void RemoveClient(Client client)
         {
-            lock (clientsLock)
-            {
-                this.clients.Remove(client);
-            }
+            clientsLock.EnterWriteLock();
+            this.clients.Remove(client);
+            clientsLock.ExitWriteLock();
         }
 
+        /// <summary>
+        /// Send the specified message to all clients in this group.
+        /// </summary>
+        /// <param name="message"></param>
         public void SendMessageToClients(Message message)
         {
+            // Lock the client list for reading, start sending messages and wait
+            // for all tasks to complete before exiting the read lock.
+            List<Task> sendDataTasks = new List<Task>();
+            clientsLock.EnterReadLock();
             foreach (Client client in this.clients)
             {
+                // Don't return the message to the original sender.
                 if (client != message.Sender)
                 {
-                    Task.Run(() => client.SendData(message));
+                    sendDataTasks.Add(Task.Run(() => client.SendData(message)));
                 }
-                
             }
+            Task.WaitAll(sendDataTasks.ToArray());
+            clientsLock.ExitReadLock();
         }
     }
 }

--- a/Messenger-Server/JsonMessage.cs
+++ b/Messenger-Server/JsonMessage.cs
@@ -1,17 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Messenger_Server
 {
     public class JsonMessage
     {
         public int GroupID { get; set; }
-        public String MessageType { get; set; }
+        public string MessageType { get; set; }
         public JsonMessagePayload Payload { get; set; }
         public DateTime DateTime { get; set; }
     }
@@ -21,8 +15,8 @@ namespace Messenger_Server
         /// <summary>
         /// mime-type
         /// </summary>
-        public String Type { get; set; }
+        public string Type { get; set; }
 
-        public String Data { get; set; }
+        public string Data { get; set; }
     }
 }

--- a/Messenger-Server/Message.cs
+++ b/Messenger-Server/Message.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 
 namespace Messenger_Server
 {
@@ -11,7 +6,7 @@ namespace Messenger_Server
     {
         //TODO dateTime.
         public Client Sender { get; set; }
-        public String MessageType
+        public string MessageType
         {
             get
             {
@@ -52,9 +47,9 @@ namespace Messenger_Server
             }
         }
 
-        private JsonMessage jsonMessage;
+        private readonly JsonMessage jsonMessage;
 
-        public Message(Client s, String json)
+        public Message(Client s, string json)
         {
             this.Sender = s;
             this.jsonMessage = Parse(json);
@@ -65,7 +60,12 @@ namespace Messenger_Server
             this.jsonMessage = new JsonMessage();
         }
 
-        private static JsonMessage Parse(String jsonString)
+        /// <summary>
+        /// Convert a string with JSON data to a JsonMessage object.
+        /// </summary>
+        /// <param name="jsonString">The string to convert.</param>
+        /// <returns>The JsonMessage object.</returns>
+        private static JsonMessage Parse(string jsonString)
         {
             JsonSerializerOptions deserializerOptions = new JsonSerializerOptions
             {
@@ -73,6 +73,12 @@ namespace Messenger_Server
             };
             return JsonSerializer.Deserialize<JsonMessage>(jsonString, deserializerOptions);
         }
+
+        /// <summary>
+        /// Serialize a message to a JSON string representation.
+        /// </summary>
+        /// <param name="m"></param>
+        /// <returns>The JSON string.</returns>
         public static string SerializeMessage(Message m)
         {
             return JsonSerializer.Serialize(m.jsonMessage);
@@ -83,11 +89,6 @@ namespace Messenger_Server
         public Message(Group g)
         {
 
-        }
-
-        public void addPayload(String data)
-        {
-            this.jsonMessage.Payload.Data = data;
         }
     }
 }


### PR DESCRIPTION
Messenger-Server:
- add: Documentation for most methods, properties and fields.
- refac: The use of "String" versus "string". The latter is used, based
on Visual Studio suggestions.
- add: Readonly modifiers to some properties and fields.
- chg: Removed unneeded usings.

Server:
- chg: Return the newly created Group instead of the GroupID when
creating a group.
- chg: Removed the client list and associated lock.

Group:
- impl: Read-write lock for client list.
- chg: Wait for all SendData tasks to complete before unlocking the
client list.

CommunicationHandler:
- impl: Upon receiving a group creation request, append the client who
requested the group to the group's client list.
- chg: Removed Parse() since it has been moved to Message.

Message:
- chg: Removed addPayload() since the PayloadData property achieves
exactly the same.