### PR TITLE
Fix COMExceptions and XAML binding failures.

### DIFF
--- a/Client/Models/Client.cs
+++ b/Client/Models/Client.cs
@@ -1,14 +1,11 @@
-﻿using System;
+﻿using Messenger_Client.Models;
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Shared;
-using Messenger_Client.Models;
 using Windows.Storage.Pickers;
-using Connection = Messenger_Client.Models.Connection;
-using Group = Messenger_Client.Models.Group;
-using System.Collections.ObjectModel;
 
 namespace Messenger_Client
 {

--- a/Client/Models/CommunicationHandler.cs
+++ b/Client/Models/CommunicationHandler.cs
@@ -119,7 +119,7 @@ namespace Messenger_Client.Models
             }
         }
 
-        private async static void HandleRegisterGroupResponse(Message message)
+        private static void HandleRegisterGroupResponse(Message message)
         {
             switch (message.GroupID)
             {
@@ -129,7 +129,7 @@ namespace Messenger_Client.Models
                     break;
                 default:
                     // Run on UI thread to prevent COMException.
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.High, () =>
+                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Idle, () =>
                     {
                         Client.Instance.AddGroup(new Group(message.GroupID, message.PayloadData));
                     });
@@ -147,7 +147,7 @@ namespace Messenger_Client.Models
             // TODO: assign to some viewmodel list (with writelock?).
         }
 
-        private async static void HandleJoinGroupResponse(Message message)
+        private static void HandleJoinGroupResponse(Message message)
         {
             switch (message.GroupID)
             {
@@ -157,7 +157,7 @@ namespace Messenger_Client.Models
                     break;
                 default:
                     // Run on UI thread to prevent COMException.
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.High, () =>
+                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Idle, () =>
                     {
                         Client.Instance.AddGroup(new Group(message.GroupID, message.PayloadData));
                     });

--- a/Client/ViewModels/AddGroupPageViewModel.cs
+++ b/Client/ViewModels/AddGroupPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Messenger_Client.Models;
 using Messenger_Client.Views;
 using Microsoft.Toolkit.Mvvm.Input;
-using System.Diagnostics;
 using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/Client/ViewModels/JoinGroupPageViewModel.cs
+++ b/Client/ViewModels/JoinGroupPageViewModel.cs
@@ -1,20 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Messenger_Client.Models;
+using Microsoft.Toolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Group = Messenger_Client.Models.Group;
+using System.Windows.Input;
 
 namespace Messenger_Client.ViewModels
 {
     class JoinGroupPageViewModel
     {
-        private Group selectedChat;
+        public ICommand JoinGroupCommand { get; set; }
 
-        public ObservableCollection<Group> GroupList;
+        private Group selectedChat;
 
         public Group SelectedChat
         {
@@ -28,10 +23,17 @@ namespace Messenger_Client.ViewModels
             }
         }
 
+        public ObservableCollection<Group> GroupList { get; set; }
+
         public JoinGroupPageViewModel()
         {
-            Debug.WriteLine(GroupList.Count);
+            JoinGroupCommand = new RelayCommand(() => JoinGroup());
+            this.GroupList = new ObservableCollection<Group>();
         }
 
+        private void JoinGroup()
+        {
+
+        }
     }
 }

--- a/Client/ViewModels/MainPageViewModel.cs
+++ b/Client/ViewModels/MainPageViewModel.cs
@@ -5,7 +5,6 @@ using Shared;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using Windows.UI.Xaml;
@@ -16,7 +15,7 @@ using Group = Messenger_Client.Models.Group;
 
 namespace Messenger_Client.ViewModels
 {
-    public class MainPageViewModel : ObservableRecipient, INotifyPropertyChanged
+    public class MainPageViewModel : ObservableRecipient
     {
         public ICommand SendMessageCommand { get; set; }
         public ICommand CheckEnterCommand { get; set; }

--- a/Client/Views/JoinGroupPage.xaml
+++ b/Client/Views/JoinGroupPage.xaml
@@ -81,7 +81,7 @@
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>
-                        <Button  Style="{ThemeResource JoinGroupButton}"/>
+                        <Button  Style="{ThemeResource JoinGroupButton}" Command="{Binding JoinGroupCommand}"/>
                         <Button  Style="{ThemeResource CancelButton}"/>
                     </StackPanel>
                 </Grid>     


### PR DESCRIPTION
Client/Models/CommunicationHandler:
- fix: Previsouly, a COMException was thrown when the response from
joining or registering a group was processed, specifically
Client.AddGroup(). The solution is to run this on the UI thread.

Client/ViewModels/JoinGroupPageViewModel:
- fix: XAML binding failures caused by binding to a field instead of a
property.
- add: Placeholder implementation for handling the join group button.

Client/ViewModels/MainPageViewModel:
- removed: Unnecessary inheritance from INotifyPropertyChanged.

Also removed unnecessary usings overall.