### PR TITLE
Schedule UI thread to run with Low priority (#31)

### DIFF
--- a/Client/Models/CommunicationHandler.cs
+++ b/Client/Models/CommunicationHandler.cs
@@ -129,7 +129,7 @@ namespace Messenger_Client.Models
                     break;
                 default:
                     // Run on UI thread to prevent COMException.
-                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Idle, () =>
+                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                     {
                         Client.Instance.AddGroup(new Group(message.GroupID, message.PayloadData));
                     });
@@ -157,7 +157,7 @@ namespace Messenger_Client.Models
                     break;
                 default:
                     // Run on UI thread to prevent COMException.
-                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Idle, () =>
+                    _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                     {
                         Client.Instance.AddGroup(new Group(message.GroupID, message.PayloadData));
                     });


### PR DESCRIPTION
Client/Models/CommunicationHandler:
- fix: ArgumentException when adding groups via the UI thread. According
to MS docs, RunAsync should have priority of Normal or Low.