### PR TITLE
Check for canceled / closed filepicker. Fix exception

### DIFF
--- a/Client/Models/Client.cs
+++ b/Client/Models/Client.cs
@@ -114,6 +114,11 @@ namespace Messenger_Client
                 this.groupLocker.ExitReadLock();
             }
 
+            if (file is null)
+            {
+                return;
+            }
+
             await Windows.Storage.FileIO.WriteTextAsync(file, csvString);
         }
 

--- a/Client/Models/Client.cs
+++ b/Client/Models/Client.cs
@@ -1,5 +1,4 @@
-﻿using Messenger_Client.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -8,7 +7,6 @@ using System.Threading.Tasks;
 using Windows.Storage.Pickers;
 using Connection = Messenger_Client.Models.Connection;
 using Group = Messenger_Client.Models.Group;
-using Windows.Storage;
 
 namespace Messenger_Client
 {
@@ -96,6 +94,11 @@ namespace Messenger_Client
             savePicker.SuggestedFileName = "New Document";
             Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();
 
+            if (file is null)
+            {
+                return;
+            }
+
             //enter read lock of groups
             this.groupLocker.EnterReadLock();
 
@@ -112,11 +115,6 @@ namespace Messenger_Client
             {
                 //exit readlock of groups
                 this.groupLocker.ExitReadLock();
-            }
-
-            if (file is null)
-            {
-                return;
             }
 
             await Windows.Storage.FileIO.WriteTextAsync(file, csvString);


### PR DESCRIPTION
When using the export filepicker there is no check in place to see if the file is set. If it is not set it would throw an exception.