### PR TITLE
Add Helper navigate, unsubscribe from events (#62)

### DIFF
--- a/Client/Models/Helper.cs
+++ b/Client/Models/Helper.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.Foundation;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Messenger_Client.Models
@@ -37,6 +41,18 @@ namespace Messenger_Client.Models
             connectionLostDialog.Content += "The connection to the server has been lost. You'll be redirected to the login page.";
 
             return connectionLostDialog;
+        }
+
+        /// <summary>
+        /// Navigate to a page. Runs on the UI thread without awaiting the result.
+        /// </summary>
+        /// <param name="pageType">The type of page to navigate to.</param>
+        public static void NavigateTo(Type pageType)
+        {
+            _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                (Window.Current.Content as Frame).Navigate(pageType);
+            });
         }
     }
 }

--- a/Client/ViewModels/AddGroupPageViewModel.cs
+++ b/Client/ViewModels/AddGroupPageViewModel.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Windows.Input;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
 namespace Messenger_Client.ViewModels
@@ -37,37 +35,34 @@ namespace Messenger_Client.ViewModels
             }
         }
 
-
         public AddGroupPageViewModel()
         {
-            BackToMainPageCommand = new RelayCommand<object>(BackToMain);
+            BackToMainPageCommand = new RelayCommand(NavigateToMain);
             AddGroupCommand = new RelayCommand(AddNewGroup);
-            CheckEnterCommand = new RelayCommand<object>(CheckEnterPressed);
+            CheckEnterCommand = new RelayCommand<KeyRoutedEventArgs>(CheckEnterPressed);
             LogoutCommand = new RelayCommand(Logout);
             AboutDialogCommand = new RelayCommand(DisplayAboutDialog);
         }
 
-        private void CheckEnterPressed(object obj)
+        private void CheckEnterPressed(KeyRoutedEventArgs keyargs)
         {
-            KeyRoutedEventArgs keyargs = (KeyRoutedEventArgs)obj;
             if (keyargs.Key == Windows.System.VirtualKey.Enter)
             {
                 AddNewGroup();
-                navigateToMain();
             }
         }
 
-        private void navigateToMain()
+        private void NavigateToMain()
         {
-            (Window.Current.Content as Frame).Navigate(typeof(MainPage));
+            Helper.NavigateTo(typeof(MainPage));
         }
 
         private void AddNewGroup()
         {
             if (this.NewGroupName != null && !this.NewGroupName.Equals(""))
             {
-                CommunicationHandler.SendRegisterGroupMessage(this.NewGroupName);
                 CommunicationHandler.RegisterGroupResponse += OnRegisterGroupResponseReceived;
+                CommunicationHandler.SendRegisterGroupMessage(this.NewGroupName);
             }
             else
             {
@@ -77,6 +72,8 @@ namespace Messenger_Client.ViewModels
 
         private async void OnRegisterGroupResponseReceived(object sender, CommunicationHandler.ResponseStateEventArgs e)
         {
+            CommunicationHandler.RegisterGroupResponse -= OnRegisterGroupResponseReceived;
+
             switch (e.State)
             {
                 case -1:
@@ -87,27 +84,16 @@ namespace Messenger_Client.ViewModels
 
                     break;
                 default:
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                    {
-                        (Window.Current.Content as Frame).Navigate(typeof(MainPage));
-                    });
-
+                    Helper.NavigateTo(typeof(MainPage));
                     break;
             }
-        }
-
-        private void BackToMain(object obj)
-        {
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(MainPage));
         }
 
         private void Logout()
         {
             Client.Instance.Connection.Close();
 
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(LoginPage));
+            Helper.NavigateTo(typeof(LoginPage));
 
             Debug.WriteLine("Logout");
         }

--- a/Client/ViewModels/LoginPageViewModel.cs
+++ b/Client/ViewModels/LoginPageViewModel.cs
@@ -75,12 +75,14 @@ namespace Messenger_Client.ViewModels
                 return;
             }
 
-            CommunicationHandler.SendLoginMessage(Email, Password);
             CommunicationHandler.LogInResponse += OnLoginInResponseReceived;
+            CommunicationHandler.SendLoginMessage(Email, Password);
         }
 
         private async void OnLoginInResponseReceived(object sender, CommunicationHandler.ResponseStateEventArgs e)
         {
+            CommunicationHandler.LogInResponse -= OnLoginInResponseReceived;
+
             switch (e.State)
             {
                 case -1:
@@ -96,10 +98,7 @@ namespace Messenger_Client.ViewModels
                     });
                     break;
                 default:
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                    {
-                        (Window.Current.Content as Frame).Navigate(typeof(MainPage));
-                    });
+                    Helper.NavigateTo(typeof(MainPage));
                 break;
             }
         }

--- a/Client/ViewModels/MainPageViewModel.cs
+++ b/Client/ViewModels/MainPageViewModel.cs
@@ -8,17 +8,10 @@ using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Windows.Input;
-using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.Storage.Streams;
-using Windows.UI;
-using Windows.UI.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 using Group = Messenger_Client.Models.Group;
-
 
 namespace Messenger_Client.ViewModels
 {
@@ -218,19 +211,12 @@ namespace Messenger_Client.ViewModels
 
         private void ShowGroupsToJoin()
         {
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(JoinGroupPage));
+            Helper.NavigateTo(typeof(JoinGroupPage));
         }
 
         private void ShowAddGroupView()
         {
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(AddGroupPage));
-        }
-
-        private void OpenSignUpView()
-        {
-            Debug.WriteLine("OpenSignUpView");
+            Helper.NavigateTo(typeof(AddGroupPage));
         }
 
         private async void ExportMessage()
@@ -247,8 +233,7 @@ namespace Messenger_Client.ViewModels
         {
             Client.Instance.Connection.Close();
 
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(LoginPage));
+            Helper.NavigateTo(typeof(LoginPage));
 
             Debug.WriteLine("Logout");
         }

--- a/Client/ViewModels/SignUpPageViewModel.cs
+++ b/Client/ViewModels/SignUpPageViewModel.cs
@@ -3,16 +3,9 @@ using Messenger_Client.Views;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 
 namespace Messenger_Client.ViewModels
 {
@@ -43,13 +36,13 @@ namespace Messenger_Client.ViewModels
 
         public SignUpPageViewModel()
         {
-            RegisterButtonCommand = new RelayCommand(() => RegisterButtonClicked());
-            GoToLoginButtonCommand = new RelayCommand(() => GoToLoginButtonClicked());
+            RegisterButtonCommand = new RelayCommand(RegisterButtonClicked);
+            GoToLoginButtonCommand = new RelayCommand(GoToLoginButtonClicked);
         }
 
         private void GoToLoginButtonClicked()
         {
-            (Window.Current.Content as Frame).Navigate(typeof(LoginPage));
+            Helper.NavigateTo(typeof(LoginPage));
         }
 
         private async void RegisterButtonClicked()
@@ -90,12 +83,14 @@ namespace Messenger_Client.ViewModels
                 return;
             }
 
-            CommunicationHandler.SendRegisterMessage(Mail, Name, Password);
             CommunicationHandler.SignUpResponse += OnSignUpResponseReceived;
+            CommunicationHandler.SendRegisterMessage(Mail, Name, Password);
         }
 
         private async void OnSignUpResponseReceived(object sender, CommunicationHandler.ResponseStateEventArgs e)
         {
+            CommunicationHandler.SignUpResponse -= OnSignUpResponseReceived;
+
             switch (e.State)
             {
                 case -1:
@@ -105,10 +100,7 @@ namespace Messenger_Client.ViewModels
                     });
                     break;
                 default:
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                    {
-                        (Window.Current.Content as Frame).Navigate(typeof(LoginPage));
-                    });
+                    Helper.NavigateTo(typeof(LoginPage));
                     break;
             }
         }


### PR DESCRIPTION
Client/Models/Helper:
- add: NavigateTo method which navigates to a page on the UI thread
without awaiting.

ViewModels:
- refac: Removed extra NavigateTo methods and use Helper.
- fix: First subscribe to events, then execute method which can invoke
them instead of the other way around.
- fix: Unsubscribe from event handlers when possible.