### PR TITLE
Do foreach loop before calling OnPropertyChanged.

### DIFF
--- a/Client/ViewModels/JoinGroupPageViewModel.cs
+++ b/Client/ViewModels/JoinGroupPageViewModel.cs
@@ -147,9 +147,9 @@ namespace Messenger_Client.ViewModels
         {
             CommunicationHandler.ObtainedRequestedGroups -= OnObtainedRequestedGroups;
 
-            await Helper.RunOnUIAsync(() => e.Groups.ForEach(group => GroupList.Add(group)));
-            Helper.RunOnUI(() =>
+            await Helper.RunOnUIAsync(() =>
             {
+                e.Groups.ForEach(group => GroupList.Add(group));
                 OnPropertyChanged("NoGroupsMessageVisibility");
                 OnPropertyChanged("ListViewVisibility");
             });


### PR DESCRIPTION
Client/ViewModels/JoinGroupPageViewModel:
- chg: Since, according to MS docs, RunAsync is not awaited (even when
using `await`), the calls to OnPropertyChanged are now executed after
the ForEach loop in the same queue instead of on a different queue in
the UI thread.